### PR TITLE
fix channels getting and'ed with 0x7, change to 0xF

### DIFF
--- a/midi-readwrite/midi-read.rkt
+++ b/midi-readwrite/midi-read.rkt
@@ -187,7 +187,7 @@
       [else 
        (cond [(not (= 0 (bitwise-and #x80 next-byte)))
               ;; new message
-              (define channel (bitwise-and #x7 next-byte))
+              (define channel (bitwise-and #xf next-byte))
               (define message-nibble (high-nibble next-byte))
               (define message-kind (bits->event-type message-nibble))
               (define parameter-1 (read-non-eof-byte port))
@@ -208,7 +208,7 @@
                         "can't continue from non-channel event")]
                 [else
                  ;; running status , the midi-evt was actually parameter 1.
-                 (define channel (bitwise-and #x7 prior-event-type-byte))
+                 (define channel (bitwise-and #xf prior-event-type-byte))
                  (define message-nibble (high-nibble 
                                          prior-event-type-byte))
                  (define message-kind (bits->event-type message-nibble))

--- a/midi-readwrite/test/example-read.rkt
+++ b/midi-readwrite/test/example-read.rkt
@@ -28,4 +28,5 @@
                                            bach-file)))
               474)
 
-
+;; test for midi events being correctly assigned channel numbers in the full range 0 to 15
+(check-equal? (ChannelMessage-channel (cadr (list-ref (list-ref (MIDIFile-tracks parsed) 14) 1))) 9)


### PR DESCRIPTION
midi-read had been only using half the available channels, meaning files expecting drums on channel 10 were instead using channel 1.